### PR TITLE
Python 3 Initial Port

### DIFF
--- a/src/cliutils.py
+++ b/src/cliutils.py
@@ -112,21 +112,21 @@ def get_terminal_size():
     """
     _tuple = (80, 25) # default
 
-    if os.name == 'nt':
-        pass
-    else:
-        which_stty = find_exe('stty')
+    #if os.name == 'nt':
+    #    pass
+    #else:
+    #    which_stty = find_exe('stty')
 
-        if which_stty:
-            args = [which_stty, 'size']
-            procs = subprocess.Popen(args, shell=False, \
-                                 stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-            (stdout_s, _) = procs.communicate()
+    #    if which_stty:
+    #        args = [which_stty, 'size']
+    #        procs = subprocess.Popen(args, shell=False, \
+    #                             stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    #        (stdout_s, _) = procs.communicate()
 
             #retcode = p.wait()
-            if stdout_s and re.search(r'^\d+ \d+$', stdout_s):
-                rows, cols = stdout_s.split()
-                _tuple = (cols, rows)
+    #        if stdout_s and re.search(r'^\d+ \d+$', stdout_s):
+    #            rows, cols = stdout_s.split()
+    #            _tuple = (cols, rows)
 
     return _tuple
 

--- a/src/extensions/COMMANDS/CommitCommand.py
+++ b/src/extensions/COMMANDS/CommitCommand.py
@@ -43,8 +43,8 @@ class CommitCommand(RdmcCommandBase):
             if not self._rdmc.app.commit(verbose=self._rdmc.opts.verbose):
                 raise NoChangesFoundOrMadeError("No changes found or made " \
                                                     "during commit operation.")
-        except Exception, excp:
-            raise excp
+        except Exception:
+            raise
 
         self.logoutobj.logoutfunction("")
 

--- a/src/extensions/COMMANDS/LoadCommand.py
+++ b/src/extensions/COMMANDS/LoadCommand.py
@@ -12,7 +12,7 @@ import json
 import shlex
 import subprocess
 
-from Queue import Queue
+from queue import Queue
 from datetime import datetime
 from optparse import OptionParser
 from rdmc_helper import ReturnCodes, InvalidCommandLineError, \
@@ -162,14 +162,14 @@ class LoadCommand(RdmcCommandBase):
                                 if self._rdmc.app.loadset(\
                                       dicttolist=dicttolist):
                                     results = True
-                            except LoadSkipSettingError, excp:
+                            except LoadSkipSettingError:
                                 returnValue = True
                                 results = True
                                 pass
-                            except Exception, excp:
-                                raise excp
-                    except Exception, excp:
-                        raise excp
+                            except Exception:
+                                raise
+                    except Exception:
+                        raise
 
                 if skip:
                     continue
@@ -177,11 +177,11 @@ class LoadCommand(RdmcCommandBase):
                 try:
                     if results:
                         self.comobj.commitfunction()
-                except NoChangesFoundOrMadeError, excp:
+                except NoChangesFoundOrMadeError:
                     if returnValue:
                         pass
                     else:
-                        raise excp
+                        raise
 
             if not results:
                 raise NoDifferencesFoundError("No differences found from " \
@@ -252,11 +252,11 @@ class LoadCommand(RdmcCommandBase):
         try:
             if runlogin:
                 self.lobobj.loginfunction(inputline)
-        except Exception, excp:
+        except Exception:
             if options.mpfilename:
                 pass
             else:
-                raise excp
+                raise
 
         #filename validations and checks
         if options.filename:
@@ -433,8 +433,8 @@ class LoadCommand(RdmcCommandBase):
                         line = str(line).replace("\n", "")
                         self.queue.put(linelist)
                         data.append(linelist)
-        except Exception, excp:
-            raise excp
+        except Exception:
+            raise
 
         if data:
             return data

--- a/src/extensions/COMMANDS/LoginCommand.py
+++ b/src/extensions/COMMANDS/LoginCommand.py
@@ -61,8 +61,8 @@ class LoginCommand(RdmcCommandBase):
                           verbose=self._rdmc.opts.verbose, \
                           path=options.path, skipbuild=skipbuild, \
                           includelogs=options.includelogs)
-        except Exception, excp:
-            raise excp
+        except Exception:
+            raise
 
         # Warning for cache enabled, since we save session in plain text
         if self._rdmc.app.config.get_cache() and not skipbuild:
@@ -95,7 +95,7 @@ class LoginCommand(RdmcCommandBase):
                 if self._rdmc.opts.verbose:
                     sys.stdout.write("Selected option: '%s'" % options.selector)
                     sys.stdout.write('\n')
-            except Exception, excp:
+            except Exception as excp:
                 raise redfish.ris.InstanceNotFoundError(excp)
 
     def loginvalidation(self, options, args):
@@ -159,8 +159,8 @@ class LoginCommand(RdmcCommandBase):
                 self.logoutobj.run("")
                 raise PathUnavailableError("The path specified by the --path"\
                                 " flag is unavailable.")
-        except Exception, excp:
-            raise excp
+        except Exception:
+            raise
 
         #Return code
         return ReturnCodes.SUCCESS

--- a/src/extensions/COMMANDS/LogoutCommand.py
+++ b/src/extensions/COMMANDS/LogoutCommand.py
@@ -53,8 +53,8 @@ class LogoutCommand(RdmcCommandBase):
         try:
             sys.stdout.write(u"Logging session out.\n")
             self.logoutfunction(line)
-        except Exception, excp:
-            raise excp
+        except Exception:
+            raise
 
         #Return code
         return ReturnCodes.SUCCESS

--- a/src/extensions/COMMANDS/SelectCommand.py
+++ b/src/extensions/COMMANDS/SelectCommand.py
@@ -95,7 +95,7 @@ class SelectCommand(RdmcCommandBase):
                                 " list of types, or pass your type by using" \
                                 " the '--selector' flag.")
 
-        except redfish.ris.InstanceNotFoundError, infe:
+        except redfish.ris.InstanceNotFoundError as infe:
             raise redfish.ris.InstanceNotFoundError(infe)
 
     def selectvalidation(self, options):

--- a/src/extensions/COMMANDS/SetCommand.py
+++ b/src/extensions/COMMANDS/SetCommand.py
@@ -110,8 +110,8 @@ class SetCommand(RdmcCommandBase):
                                 sys.stdout.write("Added the following" \
                                                                     " patch:\n")
                                 UI().print_out_json(content)
-                except Exception, excp:
-                    raise excp
+                except Exception:
+                    raise
 
             if options.commit:
                 self.comobj.commitfunction()

--- a/src/extensions/COMMANDS/TypesCommand.py
+++ b/src/extensions/COMMANDS/TypesCommand.py
@@ -67,7 +67,7 @@ class TypesCommand(RdmcCommandBase):
                 raise InvalidCommandLineError("The 'types' command does not "\
                                                         "take any arguments.")
 
-        except redfish.ris.InstanceNotFoundError, infe:
+        except redfish.ris.InstanceNotFoundError as infe:
             raise redfish.ris.InstanceNotFoundError(infe)
 
     def run(self, line):

--- a/src/extensions/RAW COMMANDS/RawPostCommand.py
+++ b/src/extensions/RAW COMMANDS/RawPostCommand.py
@@ -62,7 +62,7 @@ class RawPostCommand(RdmcCommandBase):
             try:
                 inputfile = open(args[0], 'r')
                 contentsholder = json.loads(inputfile.read())
-            except Exception, excp:
+            except Exception as excp:
                 raise InvalidFileInputError("%s" % excp)
         elif len(args) > 1:
             raise InvalidCommandLineError("Raw post only takes 1 argument.\n")

--- a/src/extensions/RAW COMMANDS/RawPutCommand.py
+++ b/src/extensions/RAW COMMANDS/RawPutCommand.py
@@ -61,7 +61,7 @@ class RawPutCommand(RdmcCommandBase):
             try:
                 inputfile = open(args[0], 'r')
                 contentsholder = json.loads(inputfile.read())
-            except Exception, excp:
+            except Exception as excp:
                 raise InvalidFileInputError("%s" % excp)
         elif len(args) > 1:
             raise InvalidCommandLineError("Raw put only takes 1 argument.\n")

--- a/src/rdmc.py
+++ b/src/rdmc.py
@@ -50,16 +50,21 @@ for name in extensions.classNames:
     try:
         extensions._Commands[cName] = getattr(\
                                         importlib.import_module(pkgName), cName)
-    except Exception, excp:
+    except Exception:
         sys.stderr.write("Error locating extension %s at location %s\n" % \
                                                 (cName, 'extensions' + name))
-        raise excp
+        raise
+
+try:
+   input = raw_input
+except NameError:
+   pass
 
 #---------End of imports---------
 
 # always flush stdout and stderr
-sys.stdout = os.fdopen(sys.stdout.fileno(), 'w', 0)
-sys.stderr = os.fdopen(sys.stderr.fileno(), 'w', 0)
+#sys.stdout = os.fdopen(sys.stdout.fileno(), 'w', 0)
+#sys.stderr = os.fdopen(sys.stderr.fileno(), 'w', 0)
 
 CLI = cliutils.CLI()
 
@@ -198,7 +203,7 @@ class RdmcCommand(RdmcCommandBase):
         if logdir:
             try:
                 os.makedirs(logdir)
-            except OSError, ex:
+            except OSError as ex:
                 if ex.errno == errno.EEXIST:
                     pass
                 else:
@@ -226,7 +231,7 @@ class RdmcCommand(RdmcCommandBase):
         if cachedir:
             try:
                 os.makedirs(cachedir)
-            except OSError, ex:
+            except OSError as ex:
                 if ex.errno == errno.EEXIST:
                     pass
                 else:
@@ -243,7 +248,7 @@ class RdmcCommand(RdmcCommandBase):
                 if self.app.config.get_cache():
                     if ("logout" not in line) and ("--logout" not in line):
                         self.app.save()
-            except Exception, excp:
+            except Exception as excp:
                 self.handle_exceptions(excp)
 
             return self.retcode
@@ -289,7 +294,7 @@ class RdmcCommand(RdmcCommandBase):
         #***************************************************
 
         while True:
-            line = raw_input(versioning.__shortname__+' > ')
+            line = input(versioning.__shortname__+' > ')
             readline.add_history(line)
 
             if not len(line):
@@ -305,7 +310,7 @@ class RdmcCommand(RdmcCommandBase):
 
                 self.retcode = self._run_command(opts, nargv)
                 self.check_for_tab_lists(nargv)
-            except Exception, excp:
+            except Exception as excp:
                 self.handle_exceptions(excp)
 
             if self.opts.verbose:
@@ -322,54 +327,54 @@ class RdmcCommand(RdmcCommandBase):
         try:
             raise
         # ****** RDMC ERRORS ******
-        except ConfigurationFileError, excp:
+        except ConfigurationFileError as excp:
             self.retcode = ReturnCodes.CONFIGURATION_FILE_ERROR
             UI().error(excp)
             sys.exit(excp.errcode)
-        except CommandNotEnabledError, excp:
+        except CommandNotEnabledError as excp:
             self.retcode = ReturnCodes.COMMAND_NOT_ENABLED_ERROR
             UI().command_not_enabled(excp)
             extensions._Commands['HelpCommand'](rdmc=self).run("")
-        except InvalidCommandLineError, excp:
+        except InvalidCommandLineError as excp:
             self.retcode = ReturnCodes.INVALID_COMMAND_LINE_ERROR
             UI().invalid_commmand_line(excp)
-        except NoCurrentSessionEstablished, excp:
+        except NoCurrentSessionEstablished as excp:
             self.retcode = ReturnCodes.NO_CURRENT_SESSION_ESTABLISHED
             UI().error(excp)
-        except NoChangesFoundOrMadeError, excp:
+        except NoChangesFoundOrMadeError as excp:
             self.retcode = ReturnCodes.NO_CHANGES_MADE_OR_FOUND
             UI().invalid_commmand_line(excp)
-        except InvalidFileInputError, excp:
+        except InvalidFileInputError as excp:
             self.retcode = ReturnCodes.INVALID_FILE_INPUT_ERROR
             UI().invalid_commmand_line(excp)
-        except InvalidCommandLineErrorOPTS, excp:
+        except InvalidCommandLineErrorOPTS as excp:
             self.retcode = ReturnCodes.INVALID_COMMAND_LINE_ERROR
-        except InvalidFileFormattingError, excp:
+        except InvalidFileFormattingError as excp:
             self.retcode = ReturnCodes.INVALID_FILE_FORMATTING_ERROR
             UI().invalid_file_formatting(excp)
-        except NoContentsFoundForOperationError, excp:
+        except NoContentsFoundForOperationError as excp:
             self.retcode = ReturnCodes.NO_CONTENTS_FOUND_FOR_OPERATION
             UI().no_contents_found_for_operation(excp)
-        except InfoMissingEntriesError, excp:
+        except InfoMissingEntriesError as excp:
             self.retcode = ReturnCodes.NO_VALID_INFO_ERROR
             UI().error(excp)
-        except InvalidOrNothingChangedSettingsError, excp:
+        except InvalidOrNothingChangedSettingsError as excp:
             self.retcode = ReturnCodes.SAME_SETTINGS_ERROR
             UI().error(excp)
-        except NoDifferencesFoundError, excp:
+        except NoDifferencesFoundError as excp:
             self.retcode = ReturnCodes.NO_CHANGES_MADE_OR_FOUND
             UI().no_differences_found(excp)
-        except MultipleServerConfigError, excp:
+        except MultipleServerConfigError as excp:
             self.retcode = ReturnCodes.MULTIPLE_SERVER_CONFIG_FAIL
             UI().multiple_server_config_fail(excp)
-        except InvalidMSCfileInputError, excp:
+        except InvalidMSCfileInputError as excp:
             self.retcode = ReturnCodes.MULTIPLE_SERVER_INPUT_FILE_ERROR
             UI().multiple_server_config_input_file(excp)
-        except FailureDuringCommitError, excp:
+        except FailureDuringCommitError as excp:
             self.retcode = ReturnCodes.FAILURE_DURING_COMMIT_OPERATION
             UI().error(excp)
         # ****** CLI ERRORS ******
-        except cliutils.CommandNotFoundException, excp:
+        except cliutils.CommandNotFoundException as excp:
             self.retcode = ReturnCodes.UI_CLI_COMMAND_NOT_FOUND_EXCEPTION
             UI().command_not_found(excp)
             extensions._Commands['HelpCommand'](rdmc=self).run("")
@@ -377,45 +382,45 @@ class RdmcCommand(RdmcCommandBase):
         except redfish.ris.UndefinedClientError:
             self.retcode = ReturnCodes.RIS_UNDEFINED_CLIENT_ERROR
             UI().error(u"Please login before making a selection")
-        except redfish.ris.InstanceNotFoundError, excp:
+        except redfish.ris.InstanceNotFoundError as excp:
             self.retcode = ReturnCodes.RIS_INSTANCE_NOT_FOUND_ERROR
             UI().printmsg(excp)
-        except redfish.ris.CurrentlyLoggedInError, excp:
+        except redfish.ris.CurrentlyLoggedInError as excp:
             self.retcode = ReturnCodes.RIS_CURRENTLY_LOGGED_IN_ERROR
             UI().error(excp)
-        except redfish.ris.NothingSelectedError, excp:
+        except redfish.ris.NothingSelectedError as excp:
             self.retcode = ReturnCodes.RIS_NOTHING_SELECTED_ERROR
             UI().nothing_selected()
-        except redfish.ris.NothingSelectedSetError, excp:
+        except redfish.ris.NothingSelectedSetError as excp:
             self.retcode = ReturnCodes.RIS_NOTHING_SELECTED_SET_ERROR
             UI().nothing_selected_set()
-        except redfish.ris.InvalidSelectionError, excp:
+        except redfish.ris.InvalidSelectionError as excp:
             self.retcode = ReturnCodes.RIS_INVALID_SELECTION_ERROR
             UI().error(excp)
-        except redfish.ris.rmc_helper.SessionExpired, excp:
+        except redfish.ris.rmc_helper.SessionExpired as excp:
             self.retcode = ReturnCodes.RIS_SESSION_EXPIRED
             self.app.logout()
             UI().printmsg(u"Current session has expired or is invalid, "\
                     "please login again with proper credentials to continue.\n")
         # ****** RMC/RIS ERRORS ******
-        except redfish.rest.v1.RetriesExhaustedError, excp:
+        except redfish.rest.v1.RetriesExhaustedError as excp:
             self.retcode = ReturnCodes.V1_RETRIES_EXHAUSTED_ERROR
             UI().retries_exhausted_attemps()
-        except redfish.rest.v1.InvalidCredentialsError, excp:
+        except redfish.rest.v1.InvalidCredentialsError as excp:
             self.retcode = ReturnCodes.V1_INVALID_CREDENTIALS_ERROR
             UI().invalid_credentials(excp)
-        except redfish.rest.v1.ServerDownOrUnreachableError, excp:
+        except redfish.rest.v1.ServerDownOrUnreachableError as excp:
             self.retcode = \
                     ReturnCodes.V1_SERVER_DOWN_OR_UNREACHABLE_ERROR
             UI().error(excp)
-        except redfish.ris.rmc_helper.InvalidPathError, excp:
+        except redfish.ris.rmc_helper.InvalidPathError as excp:
             self.retcode = ReturnCodes.RIS_REF_PATH_NOT_FOUND_ERROR
             UI().printmsg(u"Reference path not found.")
         # ****** GENERAL ERRORS ******
         except SystemExit:
             self.retcode = ReturnCodes.GENERAL_ERROR
             raise
-        except Exception, excp:
+        except Exception as excp:
             self.retcode = ReturnCodes.GENERAL_ERROR
             sys.stderr.write(u'ERROR: %s\n' % excp)
 
@@ -558,7 +563,7 @@ if __name__ == '__main__':
             try:
                 RDMC.add_command(extensions._Commands[cName](RDMC), \
                                                                 section=sName)
-            except Exception, excp:
+            except Exception as excp:
                 sys.stderr.write("Error loading extension: %s\n" % cName)
                 sys.stderr.write("\t" + excp.message + '\n')
 

--- a/src/rdmc_base_classes.py
+++ b/src/rdmc_base_classes.py
@@ -106,7 +106,7 @@ class CommandBase(object):
         lines.append(' '.join(line))
 
         sep = '\n' + (' ' * 34)
-        print "  %-28s - %s" % (self.name, sep.join(lines))
+        print("  %-28s - %s" % (self.name, sep.join(lines)))
 
     def _parse_arglist(self, line=None):
         """parses line into an options and args taking


### PR DESCRIPTION
A few notes:
1. This version no longer does unbuffered text input and output (not possible in Python3)
2. This version no longer adapts to the console size
3. This version no longer works on any Python version less than 2.7 (i.e. to work on Python 2 you need Python 2.7)